### PR TITLE
Added timeout to linux notifications

### DIFF
--- a/notify/linux/notify.py
+++ b/notify/linux/notify.py
@@ -19,6 +19,7 @@ class LinuxNotification:
     Args:
         app_name: The application name to use for this notification.
         title: The summary text.
+        timeout: Timeout for notification in milliseconds (optional)
         message: The message body text.
         image: The icon filename or icon theme-compliant name
     """
@@ -27,6 +28,7 @@ class LinuxNotification:
         self,
         message,
         title="",
+        timeout=None,
         image="dialog-information",
         app_name=None,
         **kwargs
@@ -35,4 +37,6 @@ class LinuxNotification:
         app_name = app_name or sys.argv[0]
         Notify.init(app_name)
         n = Notify.Notification.new(title, message, image)
+        if timeout is not None:
+            n.set_timeout(timeout)
         n.show()

--- a/notify/notification.py
+++ b/notify/notification.py
@@ -33,18 +33,20 @@ class Notification:
     Args:
         message: The message body.
         title: The summary text (optional).
+        timeout: notification length in milliseconds (optional).
         **kwargs: Additional arguments (optional).
     """
 
-    def __init__(self, message, title="", **kwargs):
+    def __init__(self, message, title="", timeout=None, **kwargs):
         self.message = message
         self.title = title
+        self.timeout = timeout
         self.kwargs = kwargs
 
     def __call__(self):
-        send(self.message, self.title, **self.kwargs)
+        send(self.message, self.title, self.timeout, **self.kwargs)
 
 
-def notification(message, title="", **kwargs):
-    n = Notification(message, title, **kwargs)
+def notification(message, title="", timeout=None, **kwargs):
+    n = Notification(message, title, timeout, **kwargs)
     n()


### PR DESCRIPTION
There's already a timeout option for win32, so it shouldn't be affected.