### PR TITLE
Feature/dont install tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 André P. Santos
+Copyright (c) 2023 Mateusz Bysiek
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name="notify-send",
-    version="1.1.0",
+    version="1.1.1",
     description="notify-send notify.",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author="Andre P. Santos",
     author_email="andreztz@gmail.com",
     license="MIT",
-    packages=find_packages(),
+    packages=find_packages(exclude=["test*"]),
     python_requires=">=3.6",
     install_requires=[
         "pypiwin32==223; sys_platform == 'win32'",


### PR DESCRIPTION
When building the package which is to be installed in the user's system, exclude the tests folder so that unit tests are not installed together with the package. They are not needed for the package to function in the user's environment, and can pollute the package space.

(If a user were to `import tests` somewhere, it could import tests of notify-send package).

This is a fix for:
* andreztz/notify-send#23